### PR TITLE
Fix failed test on Windows 10(JP)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,10 @@ scalaVersion := "2.12.1"
 
 scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")
 
+fork in Test := true
+
+javaOptions in Test ++= Seq("-Dfile.encoding=UTF-8")
+
 val circeVersion = "0.7.0"
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
Test `should generate error response in case of error in raw handler` and `should generate error response in case of error in case class handler` failed on Windows 10 (JP).
Because `Charset.defaultCharset().name()` returns `windows-31j` Windos 10(JP).
Test fork and specified JVM option for avoid this problem.