### PR TITLE
Update to the new lightweight aws-lambda-java-events release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ publishTo := Some(
     Opts.resolver.sonatypeStaging
 )
 
-scalaVersion := "2.12.1"
+scalaVersion := "2.12.4"
 
 import ReleaseTransformations._
 releaseProcess := Seq[ReleaseStep](
@@ -47,7 +47,7 @@ libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.24"
 
 libraryDependencies += "com.amazonaws" % "aws-lambda-java-core" % "1.2.0"
 
-libraryDependencies += "com.amazonaws" % "aws-lambda-java-events" % "1.3.0"
+libraryDependencies += "com.amazonaws" % "aws-lambda-java-events" % "2.0.2"
 
 // Test dependencies
 
@@ -56,3 +56,5 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % "test"
 libraryDependencies += "org.mockito" % "mockito-core" % "2.13.0" % "test"
 
 libraryDependencies += "ch.qos.logback" % "logback-classic" % "1.2.3" % "test"
+
+libraryDependencies += "com.amazonaws" % "aws-java-sdk" % "1.11.273" % "test"

--- a/src/main/scala/io/github/mkotsur/aws/handler/Lambda.scala
+++ b/src/main/scala/io/github/mkotsur/aws/handler/Lambda.scala
@@ -10,7 +10,6 @@ import io.circe.generic.auto._
 import io.circe.parser._
 import io.circe.syntax._
 import io.github.mkotsur.aws.proxy.{ProxyRequest, ProxyResponse}
-import org.apache.http.HttpStatus
 import org.slf4j.LoggerFactory
 import shapeless.Generic
 
@@ -46,10 +45,11 @@ object Lambda {
         (output, handledEither, _) =>
           handledEither.map { s => output.write(s.asInstanceOf[String].getBytes) }
       case _ =>
-        (output, handledEither, _) => handledEither map { handled =>
-          val jsonString = handled.asJson.noSpaces
-          output.write(jsonString.getBytes(UTF_8))
-        }
+        (output, handledEither, _) =>
+          handledEither map { handled =>
+            val jsonString = handled.asJson.noSpaces
+            output.write(jsonString.getBytes(UTF_8))
+          }
     }
   )
 
@@ -90,7 +90,7 @@ object Lambda {
           )
         case Left(e) =>
           ProxyResponse[String](
-            HttpStatus.SC_INTERNAL_SERVER_ERROR,
+            500,
             Some(Map("Content-Type" -> s"text/plain; charset=${Charset.defaultCharset().name()}")),
             Some(e.getMessage)
           )

--- a/src/main/scala/io/github/mkotsur/aws/handler/Lambda.scala
+++ b/src/main/scala/io/github/mkotsur/aws/handler/Lambda.scala
@@ -45,11 +45,10 @@ object Lambda {
         (output, handledEither, _) =>
           handledEither.map { s => output.write(s.asInstanceOf[String].getBytes) }
       case _ =>
-        (output, handledEither, _) =>
-          handledEither map { handled =>
-            val jsonString = handled.asJson.noSpaces
-            output.write(jsonString.getBytes(UTF_8))
-          }
+        (output, handledEither, _) => handledEither map { handled =>
+          val jsonString = handled.asJson.noSpaces
+          output.write(jsonString.getBytes(UTF_8))
+        }
     }
   )
 


### PR DESCRIPTION
Update to the new lightweight aws-lambda-java-events release

This PR updates the `aws-lambda-java-events` library to the latest 2.0 version. The 1.0 release series ends up including full parts of the AWS Java SDK (e.g. all of S3 SDK, all of Dynamo, etc) just so you can get some of the event types in. This is really unfortunate if you are building a lambda that doesn't even process events, or events from those specific AWS sources. AWS corrected this with the 2.0 release to help us make our lambda Jar's smaller.

No code change needed by users of this library - they just might have to import certain AWS sdks' themselves now. See: https://github.com/aws/aws-lambda-java-libs/tree/master/aws-lambda-java-events#aws-lambda-java-events-v20

FYI: The old event library was importing the `org.apache.http.HttpStatus` path - which is why I had to remove that and just provide a static 500 value instead. Hope you don't mind - this is all in the name of saving some latency time on lambdas by reducing the final jar size!

Thanks for this sweet library!