### PR TITLE
Add Scala 2.13, bump Circe versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ fork in Test := true
 
 javaOptions in Test ++= Seq("-Dfile.encoding=UTF-8")
 
-val circeVersion = "0.10.0"
+val circeVersion = "0.12.2"
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core",

--- a/build.sbt
+++ b/build.sbt
@@ -13,8 +13,9 @@ publishTo := Some(
 
 val scalaV211 = "2.11.12"
 val scalaV212 = "2.12.7"
-scalaVersion := scalaV212
-crossScalaVersions := Seq(scalaV211, scalaV212)
+val scalaV213 = "2.13.1"
+scalaVersion := scalaV213
+crossScalaVersions := Seq(scalaV211, scalaV212, scalaV213)
 
 import ReleaseTransformations._
 releaseCrossBuild := true
@@ -39,13 +40,17 @@ fork in Test := true
 
 javaOptions in Test ++= Seq("-Dfile.encoding=UTF-8")
 
-val circeVersion = "0.12.2"
+val circeVersion = "0.12.3"
+val circeVersionCompat = "0.11.2"
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core",
   "io.circe" %% "circe-generic",
   "io.circe" %% "circe-parser"
-).map(_ % circeVersion)
+).map(_ % (scalaVersion.value match {
+  case `scalaV211` => circeVersionCompat
+  case _ => circeVersion
+}))
 
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.25"
 
@@ -55,7 +60,7 @@ libraryDependencies += "com.amazonaws" % "aws-lambda-java-events" % "2.2.2"
 
 // Test dependencies
 
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.5" % "test"
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.0" % "test"
 
 libraryDependencies += "org.mockito" % "mockito-core" % "2.23.0" % "test"
 

--- a/src/main/scala/io/github/mkotsur/aws/proxy/package.scala
+++ b/src/main/scala/io/github/mkotsur/aws/proxy/package.scala
@@ -17,6 +17,7 @@ package object proxy {
 
   case class ProxyRequest[T](
       path: String,
+      pathParameters: Option[Map[String, String]] = None,
       httpMethod: String,
       headers: Option[Map[String, String]] = None,
       queryStringParameters: Option[Map[String, String]] = None,


### PR DESCRIPTION
Fixes https://github.com/mkotsur/aws-lambda-scala/issues/21 by using different Circe builds for Scala 2.11 and Scala 2.13.

Also includes @siliconmeeple's helpful change at https://github.com/mkotsur/aws-lambda-scala/commit/eaf3aae2111dd2e32706d2a74cd45e3e6badbdc2.
