### PR TITLE
update circe and scala 2.13 to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ publishTo := Some(
 
 val scalaV211 = "2.11.12"
 val scalaV212 = "2.12.13"
-val scalaV213 = "2.13.4"
+val scalaV213 = "2.13.14"
 scalaVersion := scalaV213
 crossScalaVersions := Seq(scalaV211, scalaV212, scalaV213)
 
@@ -40,7 +40,7 @@ fork in Test := true
 
 javaOptions in Test ++= Seq("-Dfile.encoding=UTF-8")
 
-val circeVersion       = "0.12.3"
+val circeVersion       = "0.14.9"
 val circeVersionCompat = "0.11.2"
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
I'm updating some versions on my project that uses this library, and I'm getting
`found version conflict(s) in library dependencies; some are suspected to be binary incompatible:`
where the dissenting version is 
`+- io.github.mkotsur:aws-lambda-scala_2.13:0.3.0      (depends on 0.12.3)`
